### PR TITLE
Use `nm-online -q` to determine online status instead of `nm-online -s -q`

### DIFF
--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  networkmanager,
   ...
 }: {
   services.tailscale = {
@@ -24,7 +23,7 @@
     before = ["network-online.target"];
     serviceConfig = {
       Type = "oneshot";
-      ExecStart = "${networkmanager}/bin/nm-online -q";
+      ExecStart = "${pkgs.networkmanager}/bin/nm-online -q";
       RemainAfterExit = "yes";
       Environment = "NM_ONLINE_TIMEOUT=60";
     };


### PR DESCRIPTION
Needs testing on wiggle first

Workaround for https://github.com/NixOS/nixpkgs/issues/180175

Closes #57