### PR TITLE
Give me wheel

### DIFF
--- a/modules/users/keyholder/tg/default.nix
+++ b/modules/users/keyholder/tg/default.nix
@@ -1,7 +1,6 @@
 {...}: {
   imports = [
     ./aa07.nix
-    ./mothblocks.nix
     ./niknak.nix
     ./watermelon.nix
   ];

--- a/modules/users/operator/default.nix
+++ b/modules/users/operator/default.nix
@@ -5,6 +5,7 @@
     ./iain0.nix
     ./ivory.nix
     ./lowrp.nix
+    ./mothblocks.nix
     ./ned.nix
     ./riggle.nix
     ./scriptis.nix

--- a/modules/users/operator/mothblocks.nix
+++ b/modules/users/operator/mothblocks.nix
@@ -10,6 +10,10 @@
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCfzjJUHmqv56u0T8vXcSOjKPEKPlcI0ujgsr8KmSsR mothblocks"
       "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDRnJC3JX9oCcvfFAUc5CQqc3PAexP7NZgr/ebemtwmJ5OxGRrSk9DuKm7C1v/CAjqw+tB+gzBGiuYFUIdIJ0Awawy91QNsqOEsDM67cDzyRLO93cLFuDgdDi/fb7fZO8lk+q8RDsbjGwL18LJsehy2eEEo+sE4QPaFbTDyGpj3uTkJG0xr/ScyD7F0bO5PQRB7lJVsPP5TUWRYW0LzhxnPfYvN0JzUJD+cxjgbn8KFYmfkE65xHbpH16MTX/mkSqmKDnbXzxDb6oHFhNrmL81/HHUHpCDbN1l2ETY+TzGER+oadBm1gQ3B72xo2tiA0JPZ1ZOTDv+x7PgdakSWEdwL root@DESKTOP-CR9ML5R"
     ];
+
+    extraGroups = [
+      "wheel"
+    ];
   };
 
   home-manager.users.mothblocks = {


### PR DESCRIPTION
Moves me into operator with wheel. Here is why:

- I have important work like parsed logs that is being regularly stalled out on various things not existing. I cannot expect other people to do the work as everyone in opsbus who would be able to is busy with a few million things.
  - There's a ton of stuff like this. It's all on mothbus and frankly if it's leagues harder to get it setup on the official hardware then I'm just not going to do it at all. I think that setting up flakes and getting PRs in and such is annoying enough, but if I have to go through several people every time then it will simply not happen
- I need to be able to test whatever nix stuff I do, and there is absolutely no chance that it's faster to try to get it all setup in some form locally when I do not have a clue what any of this stuff is
- I am paying for the servers