### PR TITLE
Use direct flake evaluation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
         "stable": "stable"
       },
       "locked": {
-        "lastModified": 1739900653,
-        "narHash": "sha256-hPSLvw6AZQYrZyGI6Uq4XgST7benF/0zcCpugn/P0yM=",
+        "lastModified": 1746808687,
+        "narHash": "sha256-X0ZNcw+wGMWPmoP90jZ525l2z+inL9kq7qG9KcTXLH4=",
         "owner": "zhaofengli",
         "repo": "colmena",
-        "rev": "2370d4336eda2a9ef29fce10fa7076ae011983ab",
+        "rev": "f3ae793ae10a1f32a360acdac0a41279c9d15c44",
         "type": "github"
       },
       "original": {
@@ -292,11 +292,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {
@@ -408,16 +408,16 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1730883749,
-        "narHash": "sha256-mwrFF0vElHJP8X3pFCByJR365Q2463ATp2qGIrDUdlE=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dba414932936fde69f0606b4f1d87c5bc0003ede",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -458,18 +458,18 @@
     "tgstation-server": {
       "locked": {
         "dir": "build/package/nix",
-        "lastModified": 1744552250,
-        "narHash": "sha256-U0EaT+NmKlboHYPAuYQ2PoYu1BPIz6V6+oq3SKRieG4=",
+        "lastModified": 1745447467,
+        "narHash": "sha256-LiimVxPbBm72H3PvShX1+o7q/u2Tcl2bCIId0KVeC98=",
         "owner": "tgstation",
         "repo": "tgstation-server",
-        "rev": "b5bc401f40a2d21cc59e839bdba0c78674113bdb",
+        "rev": "da0af26bedde229c21fb23d1bde4dee5b648c016",
         "type": "github"
       },
       "original": {
         "dir": "build/package/nix",
         "owner": "tgstation",
-        "ref": "tgstation-server-v6.16.0",
         "repo": "tgstation-server",
+        "rev": "da0af26bedde229c21fb23d1bde4dee5b648c016",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -265,6 +265,7 @@
         ];
     };
   in {
+    colemaHive = colmena.lib.makeHive self.outputs.colmena;
     colmena = {
       inherit
         tgsatan

--- a/flake.nix
+++ b/flake.nix
@@ -265,7 +265,7 @@
         ];
     };
   in {
-    colemaHive = colmena.lib.makeHive self.outputs.colmena;
+    colmenaHive = colmena.lib.makeHive self.outputs.colmena;
     colmena = {
       inherit
         tgsatan


### PR DESCRIPTION
the newest version of colmena only uses direct flake eval meaning our builds no longer work