### PR TITLE
Hotfix server updates until something better is figured out

### DIFF
--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -15,6 +15,8 @@ mkdir -p $work_directory
 
 cd $work_directory
 
+export TARGET_CC=$(which clang)
+export TARGET_CXX=$(which clang++)
 echo "rust-g: deployment begin"
 if [ ! -d "rust-g" ]; then
   echo "rust-g: cloning"
@@ -46,7 +48,10 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-env LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib)/lib" cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+
+export LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib | head -n1)/lib"
+
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 # EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
@@ -68,7 +73,7 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-env LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib)/lib" cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -51,8 +51,8 @@ echo "dreamluau: building"
 
 export LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib | head -n1)/lib"
 
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
+#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+#cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 # EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
 cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libdreamluau.so" "$1/libdreamluau.so"
@@ -73,8 +73,11 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
+#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+#cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
+
+# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
+cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libauxcpu_byondapi.so" "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"
 echo "auxcpu: deployment finish"

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -14,59 +14,59 @@
   environment.etc = {
     #TG
     "tgs-EventScripts.d/tg/DreamDaemonPreLaunch.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/DreamDaemonPreLaunch.sh);
+      text = builtins.readFile ./EventScripts/tg/DreamDaemonPreLaunch.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/parse-server.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/parse-server.sh);
+      text = builtins.readFile ./EventScripts/tg/parse-server.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/PostCompile.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/PostCompile.sh);
+      text = builtins.readFile ./EventScripts/tg/PostCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/PreCompile.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/PreCompile.sh);
+      text = builtins.readFile ./EventScripts/tg/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/tg-Roundend.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/tg-Roundend.sh);
+      text = builtins.readFile ./EventScripts/tg/tg-Roundend.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/update-config.sh" = {
-      text = (builtins.readFile ./EventScripts/tg/update-config.sh);
+      text = builtins.readFile ./EventScripts/tg/update-config.sh;
       group = "tgstation-server";
       mode = "0755";
     };
 
     #TGMC
     "tgs-EventScripts.d/tgmc/DreamDaemonPreLaunch.sh" = {
-      text = (builtins.readFile ./EventScripts/tgmc/DreamDaemonPreLaunch.sh);
+      text = builtins.readFile ./EventScripts/tgmc/DreamDaemonPreLaunch.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/PostCompile.sh" = {
-      text = (builtins.readFile ./EventScripts/tgmc/PostCompile.sh);
+      text = builtins.readFile ./EventScripts/tgmc/PostCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/PreCompile.sh" = {
-      text = (builtins.readFile ./EventScripts/tgmc/PreCompile.sh);
+      text = builtins.readFile ./EventScripts/tgmc/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/tg-Roundend.sh" = {
-      text = (builtins.readFile ./EventScripts/tgmc/tg-Roundend.sh);
+      text = builtins.readFile ./EventScripts/tgmc/tg-Roundend.sh;
       group = "tgstation-server";
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/update-config.sh" = {
-      text = (builtins.readFile ./EventScripts/tgmc/update-config.sh);
+      text = builtins.readFile ./EventScripts/tgmc/update-config.sh;
       group = "tgstation-server";
       mode = "0755";
     };
@@ -122,8 +122,10 @@
     # environmentFile =  # Required, add to host config to specify the database URI
     extra-path = lib.makeBinPath (
       with pkgs; [
-        fenix.packages.i686-linux.stable.completeToolchain
-        nixpkgs.legacyPackages.i686-linux.llvmPackages.clangUseLLVM
+        (with fenix.packages.x86_64-linux; combine [stable.toolchain targets.i686-unknown-linux-gnu.stable.rust-std])
+        clangMultiStdenv.cc
+        llvmPackages.libclang
+        which
         pkg-config
         git
         nodejs_22


### PR DESCRIPTION
rust-g has become too big for 32-bit rustc to compile so we need to install 64 bit rustc with 32 bit target. those two are not easily linked up with clang/libc however, so ive only managed to compile rustg so far. rest has to follow later.