### PR TITLE
Adds libs for rspack

### DIFF
--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -128,6 +128,7 @@
         which
         pkg-config
         git
+        nodejs_22
         bun
         dotnetCorePackages.sdk_8_0
         curl


### PR DESCRIPTION
Rspack seems to need more libraries in order to run

If this is too much, I need to revert tg to webpack, which hurts a little, but works