### PR TITLE
Raise UDP send/receive buffer sizes to 7.5MB each on all machines

### DIFF
--- a/systems/edge-nodes/base.nix
+++ b/systems/edge-nodes/base.nix
@@ -29,4 +29,8 @@
   };
 
   environment.enableAllTerminfo = true; # Enables (stable) terminfo for a bunch of extra terminals that aren't in ncurses yet (ghostty, alacritty, kitty, etc)
+
+  # Raise UDP send/recv buffer size since we rely _very_ heavily on QUIC/WireGuard
+  boot.kernel.sysctl."net.core.wmem_max" = 7500000;
+  boot.kernel.sysctl."net.core.rmem_max" = 7500000;
 }


### PR DESCRIPTION
See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes; this also applies to WireGuard (tailscale).