### PR TITLE
fix: raise tailscale MTU to 1350, apply {r,w}mem_max to all systems (not just edge nodes)

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -116,5 +116,9 @@
   programs.fish.enable = true;
   programs.zsh.enable = true;
 
+  # Raise UDP send/recv buffer size since we rely _very_ heavily on QUIC/WireGuard
+  boot.kernel.sysctl."net.core.wmem_max" = 7500000;
+  boot.kernel.sysctl."net.core.rmem_max" = 7500000;
+
   home-manager.backupFileExtension = ".hm-backup";
 }

--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -60,6 +60,11 @@
     iifname "tailscale0*" accept # Allow packets originating from tailscale to ignore reverse path filtering
   '';
 
+  # Fixup for HTTP/3 + QUIC with MTUs approaching 1280. See https://github.com/tailscale/tailscale/issues/2633.
+  services.udev.extraRules = [
+    "ACTION==\"add\", SUBSYSTEM==\"net\", KERNEL==\"tailscale0\", RUN+=\"/sbin/ip link set dev tailscale0 mtu 1500\""
+  ];
+
   systemd.services.optimize-tailscale = {
     enable = true;
     description = "fixup UDP GRO rules for tailscale";

--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -33,7 +33,7 @@
       "TS_DEBUG_FIREWALL_MODE" = "nftables";
 
       # Fixup for HTTP/3 + QUIC with MTUs approaching 1280. See https://github.com/tailscale/tailscale/issues/2633.
-      "TS_DEBUG_MTU" = 1350;
+      "TS_DEBUG_MTU" = "1350";
     };
     after = ["systemd-networkd-wait-online.service" "tgstation-wait-online.service"];
     requires = [ "tgstation-wait-online.service" ];

--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -31,7 +31,9 @@
   systemd.services.tailscaled = {
     environment = {
       "TS_DEBUG_FIREWALL_MODE" = "nftables";
-      "IM_LITERALLY_JUST_SETTING_THIS_TO_RESTART_TAILSCALED_REMOVE_IT" = "chumbis";
+
+      # Fixup for HTTP/3 + QUIC with MTUs approaching 1280. See https://github.com/tailscale/tailscale/issues/2633.
+      "TS_DEBUG_MTU" = 1350;
     };
     after = ["systemd-networkd-wait-online.service" "tgstation-wait-online.service"];
     requires = [ "tgstation-wait-online.service" ];
@@ -59,11 +61,6 @@
   networking.firewall.extraReversePathFilterRules = ''
     iifname "tailscale0*" accept # Allow packets originating from tailscale to ignore reverse path filtering
   '';
-
-  # Fixup for HTTP/3 + QUIC with MTUs approaching 1280. See https://github.com/tailscale/tailscale/issues/2633.
-  services.udev.extraRules = [
-    "ACTION==\"add\", SUBSYSTEM==\"net\", KERNEL==\"tailscale0\", RUN+=\"/sbin/ip link set dev tailscale0 mtu 1500\""
-  ];
 
   systemd.services.optimize-tailscale = {
     enable = true;

--- a/systems/edge-nodes/base.nix
+++ b/systems/edge-nodes/base.nix
@@ -29,8 +29,4 @@
   };
 
   environment.enableAllTerminfo = true; # Enables (stable) terminfo for a bunch of extra terminals that aren't in ncurses yet (ghostty, alacritty, kitty, etc)
-
-  # Raise UDP send/recv buffer size since we rely _very_ heavily on QUIC/WireGuard
-  boot.kernel.sysctl."net.core.wmem_max" = 7500000;
-  boot.kernel.sysctl."net.core.rmem_max" = 7500000;
 }


### PR DESCRIPTION
Should fix QUIC + HTTP/3 with Tailscale exit nodes as well as improve performance for Cloudflare tunnels.