### PR TITLE
Cache the entire store after builds

### DIFF
--- a/.github/workflows/colmena.yml
+++ b/.github/workflows/colmena.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Push closure to attic
         if: ${{ env.UPLOAD_TO_ATTIC == 'yes' }}
-        run: attic push tgstation:tgstation-infrastructure .gcroots/*
+        run: attic push tgstation:tgstation-infrastructure $(ls -d /nix/store/*/)
 
   deploy-staging:
     name: Deploy Staging


### PR DESCRIPTION
Worst case we push the wrong version of attic-client and colmena (only if they aren't cached)