### PR TITLE
Add header for cloudflare Real IP

### DIFF
--- a/systems/edge-nodes/systems/lemon/modules/caddy.nix
+++ b/systems/edge-nodes/systems/lemon/modules/caddy.nix
@@ -215,9 +215,7 @@ in {
             env DB_NAME {env.DB_NAME}
             env DB_USER {env.DB_USER}
             env DB_PASSWORD {env.DB_PASSWORD}
-            # Only rewrite REMOTE_ADDR for Cloudflare requests
-            env REMOTE_ADDR {http.request.header.CF-Connecting-IP} @cloudflare
-            header_up X-Real-IP {http.request.header.CF-Connecting-IP} @cloudflare
+            header_up X-CFReal-IP {http.request.header.CF-Connecting-IP} @cloudflare
           }
         '';
       };


### PR DESCRIPTION
This is because phpbb sucks and has NO support for any kind of proxy forward header
```
                // Why no forwarded_for et al? Well, too easily spoofed. With the results of my recent requests
                // it's pretty clear that in the majority of cases you'll at least be left with a proxy/cache ip.
                $ip = html_entity_decode($request->server('REMOTE_ADDR'), ENT_COMPAT);
                $ip = preg_replace('# {2,}#', ' ', str_replace(',', ' ', $ip));
```