### PR TITLE
Revert "Give ops docker group"

### DIFF
--- a/modules/users/operator/aa07.nix
+++ b/modules/users/operator/aa07.nix
@@ -12,7 +12,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
   };
 

--- a/modules/users/operator/dominion.nix
+++ b/modules/users/operator/dominion.nix
@@ -12,7 +12,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
   };
 

--- a/modules/users/operator/ivory.nix
+++ b/modules/users/operator/ivory.nix
@@ -13,7 +13,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
 
     shell = pkgs.zsh;

--- a/modules/users/operator/lorwp.nix
+++ b/modules/users/operator/lorwp.nix
@@ -13,7 +13,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
     shell = pkgs.fish;
   };

--- a/modules/users/operator/mothblocks.nix
+++ b/modules/users/operator/mothblocks.nix
@@ -13,7 +13,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
   };
 

--- a/modules/users/operator/ned.nix
+++ b/modules/users/operator/ned.nix
@@ -11,7 +11,6 @@
     ];
     extraGroups = [
       "wheel"
-      "docker"
     ];
     shell = pkgs.fish;
   };

--- a/modules/users/operator/oranges.nix
+++ b/modules/users/operator/oranges.nix
@@ -9,7 +9,6 @@
     extraGroups = [
       "redbot-user"
       "wheel"
-      "docker"
     ];
   };
 }

--- a/modules/users/operator/riggle.nix
+++ b/modules/users/operator/riggle.nix
@@ -14,7 +14,6 @@
     extraGroups = [
       "wheel"
       "db-operator"
-      "docker"
     ];
 
     shell = pkgs.zsh;

--- a/modules/users/operator/sothanforax.nix
+++ b/modules/users/operator/sothanforax.nix
@@ -13,7 +13,6 @@
 
     extraGroups = [
       "wheel"
-      "docker"
     ];
 
     shell = pkgs.zsh;

--- a/modules/users/operator/zephyrtfa.nix
+++ b/modules/users/operator/zephyrtfa.nix
@@ -14,7 +14,6 @@
     extraGroups = [
       "wheel"
       "db-operator"
-      "docker"
     ];
   };
 


### PR DESCRIPTION
This reverts commit a4dd2011989837ef0a5cbb5edc37edc56d36f9b2.

We should be using rootless docker, which is running but wasn't working for some reason? Have to figure out why.