### PR TITLE
Add 32 bit curl to TGS

### DIFF
--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -222,7 +222,7 @@
         nodejs_22
         bun
         dotnetCorePackages.sdk_8_0
-        curl
+        pkgsi686Linux.curl # DD needs 32 bit libcurl since 516.1664
         gnutar
         gzip
         coreutils # md5sum, for RSC


### PR DESCRIPTION
per the [BYOND Changelog](https://www.byond.com/docs/notes/516.html):

> world.Export() now supports POST and https requests, and enhanced web request capabilities have been added across the entire software suite. Note to Linux users: This now requires you to install 32-bit libcurl.

fixes #327 