### PR TITLE
Add date and time injection into _std/__build.dm for seasonal cycles. 

### DIFF
--- a/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
@@ -55,3 +55,18 @@ cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libauxcpu_byondapi.so" "
 
 cd "$work_directory"
 echo "auxcpu: deployment finish"
+
+# Change the build day & month, and all that, so we get nice snazzy holiday/event
+# stuff. (e.g. Halloween, Xmas, etc.)
+
+
+# match    V   this       V  & 1 or more nums - replace with matched bit in parens, plus the relevant day/month/hour/minute
+sed -Ei "s/(BUILD_TIME_DAY)\s+[[:digit:]]+/\1 `date +%-d`/" "${1}/_std/__build.dm"
+sed -Ei "s/(BUILD_TIME_MONTH)\s+[[:digit:]]+/\1 `date +%-m`/" "${1}/_std/__build.dm"
+sed -Ei "s/(BUILD_TIME_HOUR)\s+[[:digit:]]+/\1 `date +%-H`/" "${1}/_std/__build.dm"
+sed -Ei "s/(BUILD_TIME_MINUTE)\s+[[:digit:]]+/\1 `date +%-M`/" "${1}/_std/__build.dm"
+
+RSC_URL = "https\:\/\/rsc.tgstation13.org\/coolstation.rsc.zip"
+sed -Er "s/(\#define.PRELOAD_RSC_URL\s+).+/\1\"${RSC_URL}\"/g" "${1}/_std/__build.dm"
+
+echo "injected time and date to build.dm"


### PR DESCRIPTION
system time and date are necessary for some static references on turfs which would be too expensive to do at runtime 3x 3x 300,000 times. 

This copies over some of the existing infra in https://github.com/coolstation/coolstructure/blob/main/buildfusilli.sh 