### PR TITLE
Bump the rust version to fenix latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -206,17 +206,16 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1747291057,
-        "narHash": "sha256-9Wir6aLJAeJKqdoQUiwfKdBn7SyNXTJGRSscRyVOo2Y=",
+        "lastModified": 1780397302,
+        "narHash": "sha256-SQmrkj17xBdvc8lVMbsY7pIJCjKftgNh42R1keP3dLQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "76ffc1b7b3ec8078fe01794628b6abff35cbda8f",
+        "rev": "f6670530f53e69cc284f7aef818eb0f08fe81905",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "76ffc1b7b3ec8078fe01794628b6abff35cbda8f",
         "type": "github"
       }
     },
@@ -559,11 +558,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1746889290,
-        "narHash": "sha256-h3LQYZgyv2l3U7r+mcsrEOGRldaK0zJFwAAva4hV/6g=",
+        "lastModified": 1780337665,
+        "narHash": "sha256-RS3F+/6dtBIwd5+47GVen3jAk62/KumFZ4q3RVYafDk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2bafe9d96c6734aacfd49e115f6cf61e7adc68bc",
+        "rev": "55af1774e9e840d3b28d12fcfaa72d2e2caa8ac9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {
-      # fenix is pinned to that specific hash because we need 1.86 for TGS otherwise openssl can't build
-      url = "github:nix-community/fenix?rev=76ffc1b7b3ec8078fe01794628b6abff35cbda8f";
+      url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     authentik-nix = {

--- a/modules/colmena_ci.nix
+++ b/modules/colmena_ci.nix
@@ -28,4 +28,9 @@ in {
       "deploy"
     ];
   };
+
+  home-manager.users.deploy = {
+    home.file.".hushlogin".text = "";
+    home.stateVersion = config.system.stateVersion;
+  };
 }

--- a/modules/colmena_ci_staging.nix
+++ b/modules/colmena_ci_staging.nix
@@ -28,4 +28,9 @@ in {
       "deploy"
     ];
   };
+
+  home-manager.users.deploy = {
+    home.file.".hushlogin".text = "";
+    home.stateVersion = config.system.stateVersion;
+  };
 }

--- a/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
@@ -14,8 +14,6 @@ mkdir -p $work_directory
 
 cd $work_directory
 
-export TARGET_CC=$(which clang)
-export TARGET_CXX=$(which clang++)
 echo "rust-g: deployment begin"
 if [ ! -d "rust-g" ]; then
   echo "rust-g: cloning"

--- a/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
@@ -45,11 +45,8 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-#cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
-
-# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
-cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libauxcpu_byondapi.so" "$1/libauxcpu_byondapi.so"
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"
 echo "auxcpu: deployment finish"

--- a/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/cool/PreCompile.sh
@@ -27,7 +27,7 @@ fi
 echo "rust-g: checkout"
 git checkout "$RUST_G_VERSION" >/dev/null
 echo "rust-g: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu --features all
+cargo build --release --target=i686-unknown-linux-gnu --features all
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd "$work_directory"
 echo "rust-g: deployment finish"
@@ -45,7 +45,7 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"

--- a/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
@@ -28,7 +28,7 @@ fi
 echo "rust-g: checkout"
 git checkout "$RUST_G_VERSION" >/dev/null
 echo "rust-g: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu --features all
+cargo build --release --target=i686-unknown-linux-gnu --features all
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd "$work_directory"
 echo "rust-g: deployment finish"
@@ -47,7 +47,7 @@ echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
 cargo update -p ahash
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 cd "$work_directory"
@@ -66,7 +66,7 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"

--- a/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
@@ -66,11 +66,8 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-#cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
-
-# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
-cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libauxcpu_byondapi.so" "$1/libauxcpu_byondapi.so"
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"
 echo "auxcpu: deployment finish"

--- a/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
@@ -15,8 +15,6 @@ mkdir -p $work_directory
 
 cd $work_directory
 
-export TARGET_CC=$(which clang)
-export TARGET_CXX=$(which clang++)
 echo "rust-g: deployment begin"
 if [ ! -d "rust-g" ]; then
   echo "rust-g: cloning"
@@ -48,8 +46,6 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-
-export LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib | head -n1)/lib"
 
 #cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
 #cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"

--- a/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
@@ -46,12 +46,9 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-
-#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-#cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
-
-# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
-cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libdreamluau.so" "$1/libdreamluau.so"
+cargo update -p ahash
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 cd "$work_directory"
 echo "dreamluau: deployment finish"

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -28,7 +28,7 @@ fi
 echo "rust-g: checkout"
 git checkout "$RUST_G_VERSION" >/dev/null
 echo "rust-g: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu --features all
+cargo build --release --target=i686-unknown-linux-gnu --features all
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd "$work_directory"
 echo "rust-g: deployment finish"
@@ -47,7 +47,7 @@ echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
 cargo update -p ahash
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 cd "$work_directory"
@@ -66,7 +66,7 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -66,11 +66,8 @@ fi
 echo "auxcpu: checkout"
 git checkout main >/dev/null
 echo "auxcpu: building"
-#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-#cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
-
-# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
-cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libauxcpu_byondapi.so" "$1/libauxcpu_byondapi.so"
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cp target/i686-unknown-linux-gnu/release/libauxcpu_byondapi.so "$1/libauxcpu_byondapi.so"
 
 cd "$work_directory"
 echo "auxcpu: deployment finish"

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -15,8 +15,6 @@ mkdir -p $work_directory
 
 cd $work_directory
 
-export TARGET_CC=$(which clang)
-export TARGET_CXX=$(which clang++)
 echo "rust-g: deployment begin"
 if [ ! -d "rust-g" ]; then
   echo "rust-g: cloning"
@@ -48,8 +46,6 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-
-export LIBCLANG_PATH="$(find /nix/store -name *-clang-*-lib | head -n1)/lib"
 
 #cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
 #cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -46,12 +46,9 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-
-#cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
-#cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
-
-# EMERGENCY FIX, SOMETHING IS WRONG WITH THE ABOVE
-cp "${TGS_INSTANCE_ROOT}/Configuration/EventScripts.old/libdreamluau.so" "$1/libdreamluau.so"
+cargo update -p ahash
+cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu
+cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 
 cd "$work_directory"
 echo "dreamluau: deployment finish"

--- a/systems/game-servers/modules/tgs/EventScripts/tgmc/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tgmc/PreCompile.sh
@@ -7,9 +7,6 @@ original_dir="${TGS_INSTANCE_ROOT}/Configuration/EventScriptsScratch"
 cd "$1"
 . dependencies.sh
 
-export TARGET_CC=$(which clang)
-export TARGET_CXX=$(which clang++)
-
 mkdir -p "$original_dir"
 cd "$original_dir"
 

--- a/systems/game-servers/modules/tgs/EventScripts/tgmc/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tgmc/PreCompile.sh
@@ -23,7 +23,7 @@ fi
 echo "Deploying rust-g..."
 git checkout "$RUST_G_VERSION"
 
-cargo build --ignore-rust-version --release --target=i686-unknown-linux-gnu --features all
+cargo build --release --target=i686-unknown-linux-gnu --features all
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 
 # compile tgui

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -277,6 +277,21 @@
       ]
     );
   };
+
+  systemd.services.tgstation-server.environment = {
+    CC_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
+    CXX_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
+    TARGET_CC = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
+    TARGET_CXX = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
+    PKG_CONFIG_PATH_i686_unknown_linux_gnu = lib.makeSearchPath "lib/pkgconfig" (with pkgs.pkgsi686Linux; [
+      openssl.dev
+      zlib.dev
+      mariadb
+      sqlite.dev
+    ]);
+    # This helps with 32-bit bindgen/libclang issues
+    LIBCLANG_PATH = "${pkgs.pkgsi686Linux.llvmPackages.libclang.lib}/lib";
+  };
   age.secrets.rsc-cdn = {
     file = ../../secrets/rsc-cdn.age;
     owner = "${config.services.tgstation-server.username}";

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -20,8 +20,11 @@
       mariadb
       sqlite.dev
     ]);
-    # This helps with 32-bit bindgen/libclang issues
-    LIBCLANG_PATH = "${pkgs.pkgsi686Linux.llvmPackages.libclang.lib}/lib";
+    # bindgen runs on the host arch, so LIBCLANG_PATH must point at host libclang.
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+    # Still parse headers for the i686 target when cross-compiling.
+    BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu = "--target=i686-unknown-linux-gnu";
+    "BINDGEN_EXTRA_CLANG_ARGS_i686-unknown-linux-gnu" = "--target=i686-unknown-linux-gnu";
   };
 
   tgs-env-setup = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "export ${k}=\"${v}\"") tgs-env-vars);

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -28,6 +28,17 @@
   };
 
   tgs-env-setup = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "export ${k}=\"${v}\"") tgs-env-vars);
+
+  inject-env-after-shebang = script: let
+    lines = lib.splitString "\n" script;
+    first-line = lib.head lines;
+    remaining-lines = lib.tail lines;
+    rest = lib.concatStringsSep "\n" remaining-lines;
+  in
+    if lib.hasPrefix "#!" first-line then
+      "${first-line}\n${tgs-env-setup}\n${rest}"
+    else
+      "#!/usr/bin/env bash\n${tgs-env-setup}\n${script}";
 in {
   environment.systemPackages = with pkgs; [
     rclone
@@ -52,7 +63,7 @@ in {
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/PreCompile.sh" = {
-      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/tg/PreCompile.sh;
+      text = inject-env-after-shebang (builtins.readFile ./EventScripts/tg/PreCompile.sh);
       group = "tgstation-server";
       mode = "0755";
     };
@@ -86,7 +97,7 @@ in {
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/PreCompile.sh" = {
-      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/tgmc/PreCompile.sh;
+      text = inject-env-after-shebang (builtins.readFile ./EventScripts/tgmc/PreCompile.sh);
       group = "tgstation-server";
       mode = "0755";
     };
@@ -113,7 +124,7 @@ in {
       mode = "0755";
     };
     "tgs-EventScripts.d/effigy/PreCompile.sh" = {
-      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/effigy/PreCompile.sh;
+      text = inject-env-after-shebang (builtins.readFile ./EventScripts/effigy/PreCompile.sh);
       group = "tgstation-server";
       mode = "0755";
     };
@@ -147,7 +158,7 @@ in {
       mode = "0755";
     };
     "tgs-EventScripts.d/cool/PreCompile.sh" = {
-      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/cool/PreCompile.sh;
+      text = inject-env-after-shebang (builtins.readFile ./EventScripts/cool/PreCompile.sh);
       group = "tgstation-server";
       mode = "0755";
     };

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -22,9 +22,10 @@
     ]);
     # bindgen runs on the host arch, so LIBCLANG_PATH must point at host libclang.
     LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-    # Still parse headers for the i686 target when cross-compiling.
+    # Tell bindgen to parse headers for the i686 target when cross-compiling.
+    # Cargo normalises hyphens to underscores when looking up env vars, so only
+    # the underscore form is needed (and it's the only form bash can export).
     BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu = "--target=i686-unknown-linux-gnu";
-    "BINDGEN_EXTRA_CLANG_ARGS_i686-unknown-linux-gnu" = "--target=i686-unknown-linux-gnu";
   };
 
   tgs-env-setup = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "export ${k}=\"${v}\"") tgs-env-vars);

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -11,6 +11,25 @@
     rclone
   ];
 
+  # Common environment variables for 32-bit cross-compilation
+  tgs-env-vars = {
+    CC_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
+    CXX_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
+    CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
+    TARGET_CC = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
+    TARGET_CXX = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
+    PKG_CONFIG_PATH_i686_unknown_linux_gnu = lib.makeSearchPath "lib/pkgconfig" (with pkgs.pkgsi686Linux; [
+      openssl.dev
+      zlib.dev
+      mariadb
+      sqlite.dev
+    ]);
+    # This helps with 32-bit bindgen/libclang issues
+    LIBCLANG_PATH = "${pkgs.pkgsi686Linux.llvmPackages.libclang.lib}/lib";
+  };
+
+  tgs-env-setup = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "export ${k}=\"${v}\"") tgs-env-vars);
+
   # `<instance>/Configuration/EventScripts` is symlinked to these directories
   environment.etc = {
     #TG
@@ -30,7 +49,7 @@
       mode = "0755";
     };
     "tgs-EventScripts.d/tg/PreCompile.sh" = {
-      text = builtins.readFile ./EventScripts/tg/PreCompile.sh;
+      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/tg/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
@@ -64,7 +83,7 @@
       mode = "0755";
     };
     "tgs-EventScripts.d/tgmc/PreCompile.sh" = {
-      text = builtins.readFile ./EventScripts/tgmc/PreCompile.sh;
+      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/tgmc/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
@@ -91,7 +110,7 @@
       mode = "0755";
     };
     "tgs-EventScripts.d/effigy/PreCompile.sh" = {
-      text = builtins.readFile ./EventScripts/effigy/PreCompile.sh;
+      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/effigy/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
@@ -125,7 +144,7 @@
       mode = "0755";
     };
     "tgs-EventScripts.d/cool/PreCompile.sh" = {
-      text = builtins.readFile ./EventScripts/cool/PreCompile.sh;
+      text = tgs-env-setup + "\n" + builtins.readFile ./EventScripts/cool/PreCompile.sh;
       group = "tgstation-server";
       mode = "0755";
     };
@@ -278,20 +297,7 @@
     );
   };
 
-  systemd.services.tgstation-server.environment = {
-    CC_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
-    CXX_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
-    TARGET_CC = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
-    TARGET_CXX = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/c++";
-    PKG_CONFIG_PATH_i686_unknown_linux_gnu = lib.makeSearchPath "lib/pkgconfig" (with pkgs.pkgsi686Linux; [
-      openssl.dev
-      zlib.dev
-      mariadb
-      sqlite.dev
-    ]);
-    # This helps with 32-bit bindgen/libclang issues
-    LIBCLANG_PATH = "${pkgs.pkgsi686Linux.llvmPackages.libclang.lib}/lib";
-  };
+  systemd.services.tgstation-server.environment = tgs-env-vars;
   age.secrets.rsc-cdn = {
     file = ../../secrets/rsc-cdn.age;
     owner = "${config.services.tgstation-server.username}";

--- a/systems/game-servers/modules/tgs/default.nix
+++ b/systems/game-servers/modules/tgs/default.nix
@@ -6,11 +6,7 @@
   nixpkgs,
   tg-globals,
   ...
-}: {
-  environment.systemPackages = with pkgs; [
-    rclone
-  ];
-
+}: let
   # Common environment variables for 32-bit cross-compilation
   tgs-env-vars = {
     CC_i686_unknown_linux_gnu = "${pkgs.pkgsi686Linux.stdenv.cc}/bin/cc";
@@ -29,6 +25,10 @@
   };
 
   tgs-env-setup = lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "export ${k}=\"${v}\"") tgs-env-vars);
+in {
+  environment.systemPackages = with pkgs; [
+    rclone
+  ];
 
   # `<instance>/Configuration/EventScripts` is symlinked to these directories
   environment.etc = {


### PR DESCRIPTION
One - Adjusts fenix so it's always the latest
Two - injects the build vars into precompile just after the shebang, libclang, bindgen, pkgconfig and appropriate c/cpp compilers during the nix build, so they all point to the right locations.

Closes #371 
Closes #365 
Closes #141 