### PR TITLE
Edge nodes will respond to port 80 with a http page

### DIFF
--- a/systems/edge-nodes/modules/haproxy/default.nix
+++ b/systems/edge-nodes/modules/haproxy/default.nix
@@ -22,9 +22,9 @@
     + builtins.readFile ./haproxy.conf
     + ''
 
-frontend relay_status
-  mode http
-  bind *:80
-  http-request return status 200 content-type text/html lf-string "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Relay ${config.networking.hostName}</title><style>body{font-family:system-ui,sans-serif;max-width:56rem;margin:4rem auto;padding:0 1.5rem;line-height:1.5}code{padding:.15rem .35rem;background:#f3f4f6;border-radius:.35rem}</style></head><body><h1>Relay ${config.networking.hostName}</h1><p>This relay is reachable and serving traffic.</p><ul><li>Host: ${config.networking.hostName}</li><li>Client IP: %[src]</li><li>Requested Host: %[req.hdr(Host)]</li></ul></body></html>"
-'';
+      frontend relay_status from base
+        mode http
+        bind *:80
+        http-request return status 200 content-type text/html lf-string "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Relay ${config.networking.hostName}</title><style>body{font-family:system-ui,sans-serif;max-width:56rem;margin:4rem auto;padding:0 1.5rem;line-height:1.5}code{padding:.15rem .35rem;background:#f3f4f6;border-radius:.35rem}</style></head><body><h1>Relay ${config.networking.hostName}</h1><p>This relay is reachable and serving traffic.</p><ul><li>Host: ${config.networking.hostName}</li><li>Client IP: %[src]</li><li>Requested Host: %[req.hdr(Host)]</li></ul></body></html>"
+    '';
 }

--- a/systems/edge-nodes/modules/haproxy/default.nix
+++ b/systems/edge-nodes/modules/haproxy/default.nix
@@ -5,6 +5,7 @@
 
   networking.firewall.allowedTCPPorts = [
     1337 # Sybil
+    80
     3336 # Terry
     1447 # Manuel
     1887 # Manuel-2
@@ -18,5 +19,12 @@
 
   services.haproxy.config =
     "\n\n# ==== LOCAL CONFIG ====\n"
-    + builtins.readFile ./haproxy.conf;
+    + builtins.readFile ./haproxy.conf
+    + ''
+
+frontend relay_status
+  mode http
+  bind *:80
+  http-request return status 200 content-type text/html lf-string "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Relay ${config.networking.hostName}</title><style>body{font-family:system-ui,sans-serif;max-width:56rem;margin:4rem auto;padding:0 1.5rem;line-height:1.5}code{padding:.15rem .35rem;background:#f3f4f6;border-radius:.35rem}</style></head><body><h1>Relay ${config.networking.hostName}</h1><p>This relay is reachable and serving traffic.</p><ul><li>Host: ${config.networking.hostName}</li><li>Client IP: %[src]</li><li>Requested Host: %[req.hdr(Host)]</li></ul></body></html>"
+'';
 }

--- a/systems/edge-nodes/modules/haproxy/default.nix
+++ b/systems/edge-nodes/modules/haproxy/default.nix
@@ -1,4 +1,4 @@
-{...}: {
+{config, ...}: {
   imports = [
     ../haproxy_base
   ];

--- a/systems/edge-nodes/modules/haproxy_base/haproxy.conf
+++ b/systems/edge-nodes/modules/haproxy_base/haproxy.conf
@@ -15,13 +15,13 @@ backend per_ip_connections
 	# TODO: haproxy shards
 	stick-table type ip size 1m expire 1m store conn_cur,conn_rate(1m)
 
-defaults
+defaults base
 	log global
 	timeout connect 5s
 	timeout client 10s
 	timeout server 10s
 
-frontend stats
+frontend stats from base
 	mode http
 	stats enable
 	stats uri /
@@ -29,13 +29,13 @@ frontend stats
 	bind *:8888 interface tailscale0
 	stats refresh 5s
 
-frontend prometheus
+frontend prometheus from base
 	bind *:"${PROMETHEUS_PORT}" interface tailscale0
 	mode http
 	http-request use-service prometheus-exporter
 	no log
 
-defaults incoming-byond
+defaults incoming-byond from base
 	mode tcp
 	log global
 	timeout connect 5s
@@ -44,7 +44,7 @@ defaults incoming-byond
 	tcp-request connection track-sc0 src table per_ip_connections
 	tcp-request connection silent-drop if { sc_conn_cur(0) gt "$MAX_CONN" } || { sc_conn_rate(0) gt "$MAX_CONN_RATE" }
 
-defaults outgoing-byond
+defaults outgoing-byond from base
 	mode tcp
 	timeout connect 5s
 	timeout client 20s


### PR DESCRIPTION
This tells the user the host they are reaching

this should allow visiting http://manuel.tgstation13.org for example and getting the relay you're geographically assigned to

This will help us with end user debug for investigating connectivity issues