### PR TITLE
fix dreamluau compile failure

### DIFF
--- a/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/effigy/PreCompile.sh
@@ -46,6 +46,7 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
+cargo update --precise 0.8.12 ahash || true # ensure ahash is up-to-date, else compile will fail due to https://github.com/tkaitchuck/aHash/pull/183
 cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -47,6 +47,7 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
+cargo update ahash # ensure ahash is up-to-date, else compile will fail due to https://github.com/tkaitchuck/aHash/pull/183
 cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 

--- a/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
+++ b/systems/game-servers/modules/tgs/EventScripts/tg/PreCompile.sh
@@ -47,7 +47,7 @@ fi
 echo "dreamluau: checkout"
 git checkout "$DREAMLUAU_VERSION" >/dev/null
 echo "dreamluau: building"
-cargo update ahash # ensure ahash is up-to-date, else compile will fail due to https://github.com/tkaitchuck/aHash/pull/183
+cargo update --precise 0.8.12 ahash || true # ensure ahash is up-to-date, else compile will fail due to https://github.com/tkaitchuck/aHash/pull/183
 cargo build --release --target=i686-unknown-linux-gnu
 cp target/i686-unknown-linux-gnu/release/libdreamluau.so "$1/libdreamluau.so"
 


### PR DESCRIPTION
basic googling leads to https://github.com/tkaitchuck/aHash/pull/183 - the solution is to update ahash in the lockfile (i'm using `--precise` with the current latest version, because i imagine keeping it reproducible by pinning it to a specific up-to-date version is desired)

`|| true` is also appended to the end so that the build script doesn't explode if dreamluau is re-updated to a version without ahash later